### PR TITLE
Riot fix for Ruby 1.9.2

### DIFF
--- a/lib/riot/context.rb
+++ b/lib/riot/context.rb
@@ -210,7 +210,7 @@ module Riot
 
     def new_assertion(scope, what, &definition)
       if what.kind_of?(Symbol)
-        definition ||= lambda { topic.send(what) }
+        definition ||= proc { topic.send(what) }
         description = "#{scope} ##{what}"
       else
         description = "#{scope} #{what}"

--- a/lib/riot/runnable.rb
+++ b/lib/riot/runnable.rb
@@ -2,7 +2,7 @@ module Riot
   class RunnableBlock
     attr_reader :definition
     def initialize(description, &definition)
-      @description, @definition = description, definition || lambda { false }
+      @description, @definition = description, definition || proc { false }
     end
 
     def to_s; @description; end


### PR DESCRIPTION
Ruby 1.9.2 does not allow passing lambda objects to instance_eval anymore {1}.

This patch fixes this nuisance, uses "proc" instead. It passes on 1.9.2 again and still works on 1.8.7 and 1.9.1.

Regards,
Florian

{1}: According to http://www.ruby-forum.com/topic/213325 , this was always the case, it was only working by accident. 
