### PR TITLE
Asserts with arguments

### DIFF
--- a/lib/riot/context_helpers.rb
+++ b/lib/riot/context_helpers.rb
@@ -122,6 +122,9 @@ module Riot
       if what.kind_of?(Symbol)
         definition ||= proc { topic.send(what) }
         description = "#{scope} ##{what}"
+      elsif what.kind_of?(Array)
+        definition ||= proc { topic.send(*what) }
+        description = "#{scope} ##{what.shift} with argument(s): #{what}"
       else
         description = "#{scope} #{what}"
       end


### PR DESCRIPTION
I like how you in Riot can go:

```
asserts(:first).equals("foo")
```

However, I missed the ability to pass arguments to the method with a shortcut. This patch adds the ability to do just that:

```
asserts([:to_html, "hello", "world", "p"]).equals("<p>hello world</p>")
```
