### PR TITLE
Question methods

### DIFF
--- a/lib/riot/assertion_macro.rb
+++ b/lib/riot/assertion_macro.rb
@@ -48,6 +48,7 @@ module Riot
       # @param [Symbol] name the name of the macro
       def register(name)
         Assertion.register_macro name, self
+        Assertion.register_macro name.to_s + '?', self
       end
     end
 


### PR DESCRIPTION
For me it seems more natural to use #equals? rather than #equals in my tests, so I set up question method aliases for all macros.

However, I bet this is sort of an ugly hack.
