### PR TITLE
fix riot swallowing other errors

### DIFF
--- a/lib/riot.rb
+++ b/lib/riot.rb
@@ -100,7 +100,11 @@ module Riot
     Riot.reporter = Riot::PrettyDotMatrixReporter
   end
 
-  at_exit { exit(run.success?) unless Riot.alone? }
+  at_exit do
+    exit($!.status) unless $!.nil? || $!.success?
+    exit(run.success?) unless Riot.alone?
+  end
+
 end # Riot
 
 # A little bit of monkey-patch so we can have +context+ available anywhere.


### PR DESCRIPTION
somehow riot was getting required twice for us and then swallowing it's own exit code so CI didn't work. This fixed it for us
