### PR TITLE
Adding a raises_kind_of macro

### DIFF
--- a/lib/riot/assertion_macro.rb
+++ b/lib/riot/assertion_macro.rb
@@ -10,7 +10,7 @@ module Riot
   #
   #     asserts(:comments).empty?
   #     denies(:comments).empty?
-  # 
+  #
   # == Writing your own macros
   #
   # Macros are added by subclassing {AssertionMacro}. For example, here's
@@ -18,7 +18,7 @@ module Riot
   #
   #     class EmptyMacro < AssertionMacro
   #       register :empty
-  #        
+  #
   #       def evaluate(actual)
   #         actual.length == 0 ? pass : fail(expected_message(actual).to_be_empty)
   #       end
@@ -70,7 +70,7 @@ module Riot
     # @return [Array[Symbol, String]]
     def pass(message=nil) [:pass, message.to_s]; end
 
-    # Returns a status tuple indicating the assertion failed and where it failed it if that can be 
+    # Returns a status tuple indicating the assertion failed and where it failed it if that can be
     # determined.
     #
     # @param [String] message the message to report with
@@ -136,6 +136,7 @@ require 'riot/assertion_macros/matches'
 require 'riot/assertion_macros/nil'
 require 'riot/assertion_macros/not_borat'
 require 'riot/assertion_macros/raises'
+require 'riot/assertion_macros/raises_kind_of'
 require 'riot/assertion_macros/respond_to'
 require 'riot/assertion_macros/same_elements'
 require 'riot/assertion_macros/size'

--- a/lib/riot/assertion_macros/raises_kind_of.rb
+++ b/lib/riot/assertion_macros/raises_kind_of.rb
@@ -1,0 +1,76 @@
+module Riot
+  # Asserts that the test raises the expected exception, or one of its
+  # subclasses. Thus, the following assertions pass:
+  #   asserts("test") { raise My::Exception }.raises(My::Exception)
+  #   should("test") { raise My::Exception }.raises(My::Exception.superclass)
+  # The following, however, fails:
+  #   asserts("test") { raise My::Exception.superclass }.raises(My::Exception)
+  #
+  # You can also check to see if the provided message equals or matches your
+  # expectations. The message from the actual raised exception will be converted
+  # to a string before any comparison is executed.
+  #   asserts("test") { raise My::Exception, "Foo" }.raises(My::Exception, "Foo")
+  #   asserts("test") { raise My::Exception, "Foo Bar" }.raises(My::Exception, /Bar/)
+  #
+  # You can use the negative form to assert that no exception is raised at all:
+  #   denies("test") {
+  #     # do stuff
+  #   }.raises_kind_of Exception
+  #
+  # It can be used to check that a particular class of exception is not raised,
+  # in which case you should be aware that raising another kind of exception
+  # will *not* produce a failure.
+  #   denies("test") { raises ArgumentError }.raises_kind_of ArgumentError # fails
+  #   denies("test") { raises Class.new(ArgumentError) }.raises_kind_of ArgumentError # fails
+  #   denies("test") { raises "this doesn't work" }.raises_kind_of ArgumentError # passes
+  class RaisesKindOfMacro < AssertionMacro
+    register :raises_kind_of
+    expects_exception!
+
+    # (see Riot::AssertionMacro#evaluate)
+    # @param [Class] expected_class the expected Exception class
+    # @param [String, nil] expected_message an optional exception message or message partial
+    def evaluate(actual_exception, expected_class, expected_message=nil)
+      actual_message = actual_exception && actual_exception.message
+
+      if !actual_exception
+        fail new_message.expected_to_raise_kind_of(expected_class).but.raised_nothing
+      elsif !actual_exception.is_a?(expected_class)
+        fail new_message.expected_to_raise_kind_of(expected_class).not(actual_exception.class)
+      elsif expected_message && !(actual_message.to_s =~ %r[#{expected_message}])
+        fail expected_message(expected_message).for_message.not(actual_message)
+      else
+        message = new_message.raises_kind_of(expected_class)
+        pass(expected_message ? message.with_message(expected_message) : message)
+      end
+    end # evaluate
+
+    # (see Riot::AssertionMacro#devaluate)
+    # @param [Class] expected_class the unexpected Exception class
+    # @param [String, nil] expected_message an optional exception message or message partial
+    def devaluate(actual_exception, expected_class, expected_message=nil)
+      actual_message = actual_exception && actual_exception.message
+
+      if !actual_exception
+        pass new_message.raises_kind_of(expected_class)
+      elsif !actual_exception.is_a?(expected_class)
+        if expected_message && !(actual_message.to_s =~ %r[#{expected_message}])
+          pass new_message.raises_kind_of(expected_class).
+            with_message(expected_message)
+        else
+          pass new_message.raises_kind_of(expected_class)
+        end
+      else
+        message = new_message.expected_to_not_raise_kind_of(expected_class)
+
+        if expected_message
+          fail message.with_message(expected_message).but.
+            raised(actual_exception.class).
+            with_message(actual_exception.message)
+        else
+          fail message
+        end
+      end
+    end # devaluate
+  end # RaisesMacro
+end

--- a/test/core/assertion_macros/raises_kind_of_test.rb
+++ b/test/core/assertion_macros/raises_kind_of_test.rb
@@ -1,0 +1,89 @@
+require 'teststrap'
+
+class Whoops < Exception; end
+class SubWhoops < Whoops; end
+
+context "A raises_kind_of assertion macro" do
+  helper(:asserts_raises) { |o| Riot::Assertion.new("foo") { raise Whoops, o } }
+
+  assertion_test_passes("when expected exception is raised",
+                        "raises kind of Whoops") do
+    asserts_raises(nil).raises_kind_of(Whoops)
+  end
+
+  assertion_test_fails("when a superclass of the expected exception is raised",
+                       "expected to raise kind of SubWhoops, not Whoops") do
+    asserts_raises(nil).raises_kind_of(SubWhoops)
+  end
+
+  assertion_test_passes("when a subclass of the expected exception is raised",
+                        "raises kind of Exception") do
+    asserts_raises(nil).raises_kind_of(Exception)
+  end
+
+  assertion_test_fails("when nothing was raised",
+                       "expected to raise kind of Whoops, but raised nothing") do
+    assertion = Riot::Assertion.new("foo") { "barf" }.raises_kind_of(Whoops)
+  end
+
+  assertion_test_passes("when provided message equals expected message",
+                        %Q{raises kind of Whoops with message "Mom"}) do
+    asserts_raises('Mom').raises_kind_of(Whoops, 'Mom')
+  end
+
+  assertion_test_fails("when messages aren't equal",
+                       %Q{expected "Mom" for message, not "Dad"}) do
+    asserts_raises('Dad').raises_kind_of(Whoops, 'Mom')
+  end
+
+  assertion_test_passes("when provided message matches expected message",
+                        %Q{raises kind of Whoops with message /Mom/}) do
+    asserts_raises('Mom').raises_kind_of(Whoops, /Mom/)
+  end
+
+  assertion_test_fails("when messages don't match",
+                       %Q{expected /Mom/ for message, not "Dad"}) do
+    asserts_raises('Dad').raises_kind_of(Whoops, /Mom/)
+  end
+end # A raises_kind_of assertion macro
+
+context "A negative raises_kind_of assertion macro" do
+  helper(:deny_raises) { |o| Riot::Assertion.new("foo", true) { raise Whoops, o } }
+
+  assertion_test_fails("when expected exception is raised",
+                       "expected to not raise kind of Whoops") do
+    deny_raises(nil).raises_kind_of(Whoops)
+  end
+
+  assertion_test_fails("when a subclass of the expected exception is raised",
+                       "expected to not raise kind of Whoops") do
+    Riot::Assertion.new("foo", true) { raise SubWhoops }.raises_kind_of(Whoops)
+  end
+
+  assertion_test_passes("when unexpected exception is raised",
+                        "raises kind of SubWhoops") do
+    deny_raises(nil).raises_kind_of(SubWhoops)
+  end
+
+  assertion_test_passes("when nothing was raised", "raises kind of Whoops") do
+    Riot::Assertion.new("foo", true) { "barf" }.raises_kind_of(Whoops)
+  end
+
+  assertion_test_fails("when provided message equals expected message",
+                       'expected to not raise kind of Whoops with message "Mom", but raised Whoops with message "Mom"') do
+    deny_raises('Mom').raises_kind_of(Whoops, 'Mom')
+  end
+
+  assertion_test_passes("when messages and exception aren't equal",
+                        'raises kind of ArgumentError with message "Dad"') do
+    deny_raises('Mom').raises_kind_of(ArgumentError, 'Dad')
+  end
+
+  assertion_test_fails("when provided message matches expected message", 'expected to not raise kind of Whoops with message /Mom/, but raised Whoops with message "Mom"') do
+    deny_raises('Mom').raises_kind_of(Whoops, /Mom/)
+  end
+
+  assertion_test_fails("when messages don't match", "expected to not raise kind of Whoops with message /Mom/, but raised Whoops with message \"Dad\"") do
+    deny_raises('Dad').raises_kind_of(Whoops, /Mom/)
+  end
+end # A raises_kind_of assertion macro


### PR DESCRIPTION
There's something that confuses me about #raises. As stated in the documentation, it seems I'm not the only one:

```
In the negative case, you can test that an exception was not raised or that
if an exception was raised that the type of exception was different (sounds
confusing).
```

It confuses me that the following test pass:

```
denies("raising an argument error") { raise ArgumentError }.raises Exception
```

So I implemented my own macro, which uses #is_a? instead of comparing classes, which makes the above test fail (except I called my assertion #raises_kind_of instead of overriding the old one).
