### PR TITLE
Keep options in subcontexts from bleeding into parent

### DIFF
--- a/lib/riot/context.rb
+++ b/lib/riot/context.rb
@@ -51,7 +51,7 @@ module Riot
       @parent = parent || RootContext.new([],[], "", {})
       @description = description
       @contexts, @setups, @assertions, @teardowns = [], [], [], []
-      @options = @parent.option_set
+      @options = @parent.option_set.dup
       prepare_middleware(&definition)
     end
 

--- a/test/core/context/context_with_options_test.rb
+++ b/test/core/context/context_with_options_test.rb
@@ -29,5 +29,8 @@ context "Context with options" do
 
     asserts("option :goo") { topic.option(:goo) }.equals("car")
     asserts("option \"car\"") { topic.option("car") }.equals(3)
+    asserts("option :goo on parent") do
+      topic.parent.option(:goo)
+    end.equals(nil)
   end # and with a nested context
 end # Context with options


### PR DESCRIPTION
The option hash got passed to the subcontexts by reference,
so options on a subcontext would overwrite or add options
to their parent context.
