### PR TITLE
Using #inspect rather than #to_s for assertions made with arguments

### DIFF
--- a/lib/riot/context_helpers.rb
+++ b/lib/riot/context_helpers.rb
@@ -81,7 +81,7 @@ module Riot
     #   asserts(:size).equals(2)
     #
     # Or with arguments:
-    # 
+    #
     #   asserts(:foo,1,2).equals(3)
     #
     # Passing a Symbol to +asserts+ enables this behaviour. For more information on
@@ -178,12 +178,12 @@ module Riot
       denies(what) { topic }
     end
   private
-    
+
     def new_assertion(scope, *args, &definition)
       options = args.extract_options!
       definition ||= proc { topic.send(*args) }
       description = "#{scope} #{args.first}"
-      description << " with arguments(s): #{args.slice(1, args.length)}" if args.size > 1
+      description << " with arguments(s): #{args.slice(1, args.length).inspect}" if args.size > 1
       (@assertions << assertion_class.new(description, options[:negative], &definition)).last
     end
 

--- a/test/core/reports/dot_matrix_reporter_test.rb
+++ b/test/core/reports/dot_matrix_reporter_test.rb
@@ -16,7 +16,7 @@ context "DotMatrixReporter" do
     end
     asserts_topic('puts a dot').matches('.')
   end
-  
+
   context 'with a failing test' do
     setup do
       Riot::Context.new('whatever') do
@@ -25,12 +25,12 @@ context "DotMatrixReporter" do
       topic.results(100)
       @out.string
     end
-    
+
     asserts_topic('puts an F').matches('F')
     asserts_topic("puts the full context + assertion name").matches('whatever asserts nope!')
     asserts_topic("puts the failure reason").matches(/Expected .* but got false instead/)
   end
-  
+
   context 'with an error test' do
     setup do
       Riot::Context.new('whatever') do
@@ -39,7 +39,7 @@ context "DotMatrixReporter" do
       topic.results(100)
       @out.string
     end
-    
+
     asserts_topic('puts an E').matches('E')
     asserts_topic('puts the full context + assertion name').matches('whatever asserts bang')
     asserts_topic('puts the exception message').matches('BOOM')


### PR DESCRIPTION
When an assertion is made with arguments, we get a somewhat ugly output in 1.8 because of what `Array#to_s` looks like (it just joins the element without printing anything between them). `#inspect` makes the output readable.
