### PR TITLE
Correct the arity on Report#initialize

### DIFF
--- a/lib/riot/reporter.rb
+++ b/lib/riot/reporter.rb
@@ -22,7 +22,8 @@ module Riot
     attr_accessor :current_context
 
     # Creates a new Reporter instance and initializes counts to zero
-    def initialize
+    def initialize(*args)
+      @options = args.extract_options!
       @passes = @failures = @errors = 0
       @current_context = ""
     end

--- a/lib/riot/reporter/io.rb
+++ b/lib/riot/reporter/io.rb
@@ -13,8 +13,8 @@ module Riot
     # @param [IO] writer the writer to use for results
     # @param [Hash] options options for reporter
     def initialize(*args)
-      super()
-      @options = (args.last.kind_of?(Hash) ? args.pop : {})
+      super
+      @options = args.extract_options!
       @writer = (args.shift || STDOUT)
     end
 

--- a/test/core/reports/basic_reporter_test.rb
+++ b/test/core/reports/basic_reporter_test.rb
@@ -51,6 +51,7 @@ context "A reporter" do
   context "instance" do
     setup { Riot::Reporter.new }
     should("return self invoking new") { topic.new }.equals { topic }
+    should("accept an options hash") { topic.new({}) }.equals { topic }
   end
 
   context "with no errors or failures" do


### PR DESCRIPTION
`Report#initialize` is supposed to take a list of options. Interestingly enough, calling `super` in `initialize`  passes a copy of *args. Mutating *args in the superclass isn't reflected in the inherited class.

Fixes issue #47
